### PR TITLE
Fix deprecation of is_literal_type.

### DIFF
--- a/src/include/boost/hana/traits.hpp
+++ b/src/include/boost/hana/traits.hpp
@@ -68,7 +68,9 @@ BOOST_HANA_NAMESPACE_BEGIN namespace traits {
     constexpr auto is_trivially_copyable = detail::hana_trait<std::is_trivially_copyable>{};
     constexpr auto is_standard_layout = detail::hana_trait<std::is_standard_layout>{};
     constexpr auto is_pod = detail::hana_trait<std::is_pod>{};
+#if __cplusplus < 201703L
     constexpr auto is_literal_type = detail::hana_trait<std::is_literal_type>{};
+#endif
     constexpr auto is_empty = detail::hana_trait<std::is_empty>{};
     constexpr auto is_polymorphic = detail::hana_trait<std::is_polymorphic>{};
     constexpr auto is_abstract = detail::hana_trait<std::is_abstract>{};

--- a/src/test/type/traits.cpp
+++ b/src/test/type/traits.cpp
@@ -54,7 +54,9 @@ int main() {
     hana::traits::is_trivially_copyable(s);
     hana::traits::is_standard_layout(s);
     hana::traits::is_pod(s);
+#if __cplusplus < 201703L
     hana::traits::is_literal_type(s);
+#endif
     hana::traits::is_empty(s);
     hana::traits::is_polymorphic(s);
     hana::traits::is_abstract(s);


### PR DESCRIPTION
is_literal_type was deprecated in C++-17 and is causing build errors
along the lines of

    (openmc) nick@lemur:~/code/NJOY21/bin$ make
    [ 58%] Built target njoy
    [ 63%] Built target njoy_c_bindings
    [ 85%] Built target utility
    Consolidate compiler generated dependencies of target njoy21
    [ 86%] Building CXX object CMakeFiles/njoy21.dir/src/main.cpp.o
    In file included from /home/nick/code/NJOY21/bin/_deps/hana-adapter-src/src/include/boost/hana.hpp:191,
                     from /home/nick/code/NJOY21/bin/_deps/endftk-src/src/ENDFtk/section/6.hpp:8,
                     from /home/nick/code/NJOY21/bin/_deps/endftk-src/src/ENDFtk.hpp:19,
                     from /home/nick/code/NJOY21/src/njoy21.hpp:16,
                     from /home/nick/code/NJOY21/src/main.cpp:1:
    /home/nick/code/NJOY21/bin/_deps/hana-adapter-src/src/include/boost/hana/traits.hpp:71:62: error: ‘template<class _Tp> struct std::is_literal_type’ is deprecated [-Werror=deprecated-declarations]
       71 |     constexpr auto is_literal_type = detail::hana_trait<std::is_literal_type>{};
          |                                                              ^~~~~~~~~~~~~~~
    In file included from /usr/include/c++/11/variant:36,
                     from /home/nick/code/NJOY21/src/njoy21.hpp:4,
                     from /home/nick/code/NJOY21/src/main.cpp:1:
    /usr/include/c++/11/type_traits:746:5: note: declared here
      746 |     is_literal_type
          |     ^~~~~~~~~~~~~~~

The fix for this was made upstream in
https://github.com/boostorg/hana/commit/9cd5744df7517138a50f238c4b26232e65ba3121
and this change just brings in that fix into this branch.

Fixes https://github.com/njoy/NJOY21/issues/168